### PR TITLE
Fix dependencies issue in pom

### DIFF
--- a/spring-boot-starters/spring-boot-starter-data-cassandra/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-cassandra/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starters</artifactId>
-		<version>1.2.1.BUILD-SNAPSHOT</version>
+		<version>1.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-boot-starter-data-cassandra</artifactId>
 	<name>Spring Boot Data Cassandra Starter</name>


### PR DESCRIPTION
The Spring Boot starter for Cassandra misspelled the current in use
version of the spring-boot-starters parent pom.
